### PR TITLE
Integrate support modelling into workflow

### DIFF
--- a/actions/iovrmr_actions.py
+++ b/actions/iovrmr_actions.py
@@ -101,7 +101,13 @@ def write_amiris_config(data_manager, config, params):
         translation_map = load_yaml(amiris_map)
         if "Agents" not in translation_map:
             raise_and_log_critical_error("Found no Agents to create/append in {}.".format(amiris_maps))
-        config_file, inserted_agents = insert_agents_from_map(data, translation_map["Agents"], config_file)
+        config_and_agents = insert_agents_from_map(data, translation_map["Agents"], config_file)
+        config_file = config_and_agents[0]
+        inserted_agents = config_and_agents[1]
+        try:
+            res_operators_and_traders = config_and_agents[2]
+        except IndexError:
+            pass
         if "Contracts" in translation_map:
             config_file = insert_contracts_from_map(inserted_agents, translation_map["Contracts"], config_file)
 

--- a/amiris_workflow/amiris-config/biogasFieldMap.yaml
+++ b/amiris_workflow/amiris-config/biogasFieldMap.yaml
@@ -21,7 +21,7 @@ Agents:
 
 
 AgentGroups:
-  - &marketer 2
+  - &marketer 11
 
 Contracts:
 #################################

--- a/amiris_workflow/amiris-config/renewablesFieldMap.yaml
+++ b/amiris_workflow/amiris-config/renewablesFieldMap.yaml
@@ -12,7 +12,7 @@ Agents:
       - attribute: Attributes/EnergyCarrier
         value: PV
       - attribute: Attributes/SupportInstrument
-        value: FIT
+        column: SupportInstrument
       - attribute: Attributes/InstalledPowerInMW
         column: InstalledPowerInMW
       - attribute: Attributes/OpexVarInEURperMWH
@@ -33,7 +33,7 @@ Agents:
       - attribute: Attributes/EnergyCarrier
         value: PV
       - attribute: Attributes/SupportInstrument
-        value: FIT
+        column: SupportInstrument
       - attribute: Attributes/InstalledPowerInMW
         column: InstalledPowerInMW
       - attribute: Attributes/OpexVarInEURperMWH
@@ -54,7 +54,7 @@ Agents:
       - attribute: Attributes/EnergyCarrier
         value: WindOn
       - attribute: Attributes/SupportInstrument
-        value: FIT
+        column: SupportInstrument
       - attribute: Attributes/InstalledPowerInMW
         column: InstalledPowerInMW
       - attribute: Attributes/OpexVarInEURperMWH
@@ -75,7 +75,7 @@ Agents:
       - attribute: Attributes/EnergyCarrier
         value: WindOff
       - attribute: Attributes/SupportInstrument
-        value: FIT
+        column: SupportInstrument
       - attribute: Attributes/InstalledPowerInMW
         column: InstalledPowerInMW
       - attribute: Attributes/OpexVarInEURperMWH
@@ -96,7 +96,7 @@ Agents:
       - attribute: Attributes/EnergyCarrier
         value: RunOfRiver
       - attribute: Attributes/SupportInstrument
-        value: FIT
+        column: SupportInstrument
       - attribute: Attributes/InstalledPowerInMW
         column: InstalledPowerInMW
       - attribute: Attributes/OpexVarInEURperMWH
@@ -124,7 +124,7 @@ Agents:
         value: "amiris-config/data/otherres.csv"
 
 AgentGroups:
-  - &marketer 2
+  - &marketer 11
 
 Contracts:
 #################################
@@ -180,3 +180,53 @@ Contracts:
     ProductName: Payout
     FirstDeliveryTime: 2626204
     DeliveryIntervalInSteps: 2628000
+
+
+#SupportAgentGroups:
+#  - &exchange 1
+#  - &policy 90
+#  - &marketers []
+#  - &supportedMarketers []
+#
+#SupportPolicyContracts:
+#  - SenderId: *supportedMarketers
+#    ReceiverId: *policy
+#    ProductName: SupportInfoRequest
+#    FirstDeliveryTime: -35
+#    DeliveryIntervalInSteps: 31536000
+#
+#  - SenderId: *policy
+#    ReceiverId: *supportedMarketers
+#    ProductName: SupportInfo
+#    FirstDeliveryTime: -33
+#    DeliveryIntervalInSteps: 31536000
+#
+#  - SenderId: *exchange
+#    ReceiverId: *policy
+#    ProductName: Awards
+#    FirstDeliveryTime: 4
+#    DeliveryIntervalInSteps: 3600
+#
+#  - SenderId: *marketers
+#    ReceiverId: *policy
+#    ProductName: YieldPotential
+#    FirstDeliveryTime: 1
+#    DeliveryIntervalInSteps: 3600
+#
+#  - SenderId: *supportedMarketers
+#    ReceiverId: *policy
+#    ProductName: SupportPayoutRequest
+#    FirstDeliveryTime: 2626200
+#    DeliveryIntervalInSteps: 2628000
+#
+#  - SenderId: *policy
+#    ReceiverId: *supportedMarketers
+#    ProductName: SupportPayout
+#    FirstDeliveryTime: 2626202
+#    DeliveryIntervalInSteps: 2628000
+#
+#  - SenderId: *policy
+#    ReceiverId: *policy
+#    ProductName: MarketValueCalculation
+#    FirstDeliveryTime: 2626204
+#    DeliveryIntervalInSteps: 2628000

--- a/amiris_workflow/amiris-config/scenario_template.yaml
+++ b/amiris_workflow/amiris-config/scenario_template.yaml
@@ -25,6 +25,14 @@ Agents:
     Attributes:
       ShareOfRevenues: 0.0
 
+  - Type: RenewableTrader
+    Id: 3
+    Attributes:
+      ShareOfRevenues: 0.0
+
+  - Type: SystemOperatorTrader
+    Id: 4
+
   - Type: DemandTrader
     Id: 5
     Attributes:

--- a/amiris_workflow/amiris-config/scenario_template.yaml
+++ b/amiris_workflow/amiris-config/scenario_template.yaml
@@ -21,17 +21,17 @@ Agents:
       GateClosureInfoOffsetInSeconds: 11
 
   - Type: NoSupportTrader
-    Id: 2
+    Id: 11
     Attributes:
       ShareOfRevenues: 0.0
 
   - Type: RenewableTrader
-    Id: 3
+    Id: 12
     Attributes:
       ShareOfRevenues: 0.0
 
   - Type: SystemOperatorTrader
-    Id: 4
+    Id: 13
 
   - Type: DemandTrader
     Id: 5
@@ -49,7 +49,7 @@ Agents:
     Id: 90
     Attributes:
       SetSupportData:
-        # Add first dummy list entry since FAME does not allow for empty lists
+        # Add first dummy list entry since FAME does not allow for empty lists (in case no support is considered)
         - Set: Undefined
           FIT:
             TsFit: 0

--- a/amiris_workflow/amiris-config/scenario_template.yaml
+++ b/amiris_workflow/amiris-config/scenario_template.yaml
@@ -37,6 +37,15 @@ Agents:
       ForecastPeriodInHours: 168
       ForecastRequestOffsetInSeconds: 27
 
+  - Type: SupportPolicy
+    Id: 90
+    Attributes:
+      SetSupportData:
+        # Add first dummy list entry since FAME does not allow for empty lists
+        - Set: Undefined
+          FIT:
+            TsFit: 0
+
   - Type: IndividualPlantBuilder
     Id: 2000
     Attributes:

--- a/amiris_workflow/amiris-config/supportPolicyFieldMap.yaml
+++ b/amiris_workflow/amiris-config/supportPolicyFieldMap.yaml
@@ -1,0 +1,63 @@
+AgentGroups:
+  - &support 90
+
+Agents:
+  # FIT
+  - column: SupportInstrument
+    target: FIT
+    append:
+      - agent: *support
+        below: Attributes/SetSupportData
+        elements:
+          - attribute: Set
+            column: Set
+          - attribute: FIT/TsFit
+            column: FIT
+
+  # MPVAR
+  - column: SupportInstrument
+    target: MPVAR
+    append:
+      - agent: *support
+        below: Attributes/SetSupportData
+        elements:
+          - attribute: Set
+            column: Set
+          - attribute: MPVAR/Lcoe
+            column: Lcoe
+
+  # MPFIX
+  - column: SupportInstrument
+    target: MPFIX
+    append:
+      - agent: *support
+        below: Attributes/SetSupportData
+        elements:
+          - attribute: Set
+            column: Set
+          - attribute: MPFIX/Premium
+            column: Premium
+
+  # CFD
+  - column: SupportInstrument
+    target: CFD
+    append:
+      - agent: *support
+        below: Attributes/SetSupportData
+        elements:
+          - attribute: Set
+            column: Set
+          - attribute: CFD/Lcoe
+            column: Lcoe
+
+  # CP
+  - column: SupportInstrument
+    target: CP
+    append:
+      - agent: *support
+        below: Attributes/SetSupportData
+        elements:
+          - attribute: Set
+            column: Set
+          - attribute: CP/Premium
+            column: Premium

--- a/amiris_workflow/amiris-config/yaml/contracts/renewables_standard_contracts.yaml
+++ b/amiris_workflow/amiris-config/yaml/contracts/renewables_standard_contracts.yaml
@@ -1,6 +1,6 @@
 AgentGroups:
   - &exchange 1
-  - &marketer 2
+  - &marketer 11
   - &forecaster 6
 
 Contracts:

--- a/amiris_workflow/user.yaml
+++ b/amiris_workflow/user.yaml
@@ -133,6 +133,17 @@ workflow:
         templateFile: amiris-config/scenario.yaml
         outputFile: scenario.yaml
 
+  - action:
+      project: general
+      call: write_amiris_config
+      data:
+        read_from_dmgr: renewables
+        write_to_dmgr: null
+      args:
+        AMIRISConfigFieldMap: amiris-config/supportPolicyFieldMap.yaml
+        templateFile: amiris-config/scenario.yaml
+        outputFile: scenario.yaml
+
   # Add biogas (append to scenario)
   - action:
       project: general


### PR DESCRIPTION
This comprises the following:
- [x] Add new agents: renewable traders + support policy
- [x] Add mapping for support policy
- [x] Map renewable operators to their respective marketer
- [ ] Adjust contracts to match given input data