### PR TITLE
Allow for policy (non-)consideration

### DIFF
--- a/actions/iovrmr_actions.py
+++ b/actions/iovrmr_actions.py
@@ -109,9 +109,13 @@ def write_amiris_config(data_manager, config, params):
         except IndexError:
             res_operators_and_traders = None
         if "Contracts" in translation_map:
-            config_file = insert_contracts_from_map(
-                inserted_agents, translation_map["Contracts"], config_file, res_operators_and_traders, data
-            )
+            # If not support is modelled, SupportPolicy agent and attributed contracts are missing
+            if not inserted_agents and amiris_map == "amiris-config/supportPolicyFieldMap.yaml":
+                inserted_agents = [{"SupportPolicy": 90}]
+            if inserted_agents:
+                config_file = insert_contracts_from_map(
+                    inserted_agents, translation_map["Contracts"], config_file, res_operators_and_traders, data
+                )
 
     write_yaml(config_file, output_file_path)
 

--- a/actions/iovrmr_tools.py
+++ b/actions/iovrmr_tools.py
@@ -371,7 +371,8 @@ def fill_contracts_list(data: list, translation_map: list):
                 else:
                     value = get_field(translation, field)
                 contract.update({field: value})
-            contract_list.append(contract)
+            if contract["SenderId"] and contract["ReceiverId"]:
+                contract_list.append(contract)
 
     return contract_list
 
@@ -406,7 +407,8 @@ def fill_contracts_list_for_res(data: list, translation_map: list, res_operators
                 else:
                     value = get_field(translation, field)
                 contract.update({field: value})
-            contract_list.append(contract)
+            if contract["SenderId"] and contract["ReceiverId"]:
+                contract_list.append(contract)
 
     return contract_list
 
@@ -444,7 +446,8 @@ def fill_contracts_list_for_policy(data: list, translation_map: list, raw_data: 
                 else:
                     value = get_field(translation, field)
                 contract.update({field: value})
-            contract_list.append(contract)
+            if contract["SenderId"] and contract["ReceiverId"]:
+                contract_list.append(contract)
 
     return contract_list
 


### PR DESCRIPTION
Avoid crashes due to missing policy or agent specification:
* Allow for "bypassing" SupportPolicy agent while keeping the necessary bidding contracts for RES and their 1:1 marketer.
* Prevent contracts with either empty sender or empty receiver list from being added - which would lead to an Error thrown by fameio.