### PR TITLE
Fix problem with new fameio version

### DIFF
--- a/actions/iovrmr_actions.py
+++ b/actions/iovrmr_actions.py
@@ -11,7 +11,7 @@ import yaml
 from fameio.scripts.convert_results import run as convert_results
 from fameio.scripts.make_config import DEFAULT_CONFIG
 from fameio.scripts.make_config import run as make_config
-from fameio.source.cli import Options, ResolveOptions
+from fameio.source.cli import Options, ResolveOptions, TimeOptions
 from fameio.source.loader import load_yaml
 from ioproc.tools import action
 
@@ -202,6 +202,7 @@ def convert_pb(data_manager, config, params):
         Options.SINGLE_AGENT_EXPORT: False,
         Options.MEMORY_SAVING: False,
         Options.RESOLVE_COMPLEX_FIELD: ResolveOptions.SPLIT,
+        Options.TIME: TimeOptions.INT.name,
     }
 
     ensure_path_exists(run_config[Options.OUTPUT])


### PR DESCRIPTION
FAME-Io version `1.8` introduced new option `TIME`. Thereby, the default is now `UTC`, i.e. a human-readable UTC time stamp. The problem is that the workflow has been set up using the former default (INT) which is an integer representation of the simulation tick at which the output was written. This is fixed by this PR.